### PR TITLE
Repair usage of `QMAKE_LRELEASE`

### DIFF
--- a/vokoscreen.pro
+++ b/vokoscreen.pro
@@ -16,21 +16,29 @@ FORMS += vokoscreen.ui
 # Um der Fehlermeldung entgegenzuwirken das keine *.qm Dateien vorhanden sind wird lrelease als Systemaufruf vorher aufgerufen.
 # Das Script/Macro siehe weiter unten "# language packages" muß weiter bestehen bleiben damit "make clean" die *.qm Dateien löscht.
 
-system(lrelease-qt5 language/vokoscreen_*.ts)
+isEmpty(QMAKE_LRELEASE) {
+  # Try invocation path of qmake for lrelease
+  # NOTE: Usually from Qt Unified Installer
+  win32: QMAKE_LRELEASE = $$[QT_INSTALL_BINS]\lrelease.exe
+    else: QMAKE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease
+    
+  # As a last resort try to use lrelease from PATH
+  # NOTE: Usually from a distro package
+  unix:!exists($$QMAKE_LRELEASE) {
+    QMAKE_LRELEASE = lrelease-qt5
+  }
+}    
+
+system($$QMAKE_LRELEASE language/vokoscreen_*.ts)
 
 RESOURCES += screencast.qrc
                         
 TRANSLATIONS = $$files(language/vokoscreen_*.ts)
 
 # language packages
-
 !isEmpty(TRANSLATIONS) {
-  isEmpty(QMAKE_LRELEASE) {
-    win32: QMAKE_LRELEASE = $$[QT_INSTALL_BINS]\lrelease.exe
-      else: QMAKE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease-qt5
-  }
   isEmpty(TS_DIR):TS_DIR = language
-  TSQM.name = lrelease-qt5 ${QMAKE_FILE_IN}
+  TSQM.name = $$QMAKE_LRELEASE ${QMAKE_FILE_IN}
   TSQM.input = TRANSLATIONS
   TSQM.output = $$TS_DIR/${QMAKE_FILE_BASE}.qm
   TSQM.commands = $$QMAKE_LRELEASE ${QMAKE_FILE_IN}


### PR DESCRIPTION
Since my distro distributes Qt 5.6.1 in package form *(probably the same in yours but perhaps a different version)* this change will allow those using the Qt Unified Installer to not get error messages when Qt Linguist **and** it's support tools aren't installed by default. In my distro the package name is called `qt5-linguist-tools` however it's version 5.6.1 and that's what the symlink points to of `lrelease-qt5`. 

So after using [the Qt Unified Installer](https://download.qt.io/official_releases/online_installers/) as `su` *(NOTE: __not__ `sudo su` or the path changes to non-global)* this should properly pick the correct version of `lrelease` when compiling.

Build session:

``` sh-session
make distclean
/opt/Qt/5.10.0/gcc_64/bin/qmake
make
sudo make install
```

Related historical issues:
* #104
* #138
* Perhaps some others from [a search](https://github.com/vkohaupt/vokoscreen/search?q=cannot+find+file+qm&type=Issues&utf8=%E2%9C%93)